### PR TITLE
Try fixing publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types:
       - closed
+    paths:
+      - Dockerfile
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,12 @@
 name: Publish image
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - Dockerfile
+  pull_request:
+    types:
+      - closed
 
 jobs:
   publish:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
* Problem seems to be that GitHub is preventing from spawning Actions when GITHUB_TOKEN is used for a push event (which it is when using github-actions bot to merge dependabot PRs into main). Docs: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
* This attempt tries to go the route of getting triggered by a PR-merge into main

